### PR TITLE
feat: add num_workers pram

### DIFF
--- a/train.py
+++ b/train.py
@@ -17,7 +17,7 @@ num_epochs = 300
 train_dataset = SRDataset(div2k_path)
 train_loader = DataLoader(train_dataset,
                          batch_size=batch_size,
-                         shuffle=True)
+                         shuffle=True, num_workers=4)
 
 # 모델, 손실함수, 옵티마이저 설정
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')


### PR DESCRIPTION
고성능 gpu 사용시 데이터 로더에서 gpu로 데이터가 전달이 되지 않는 현상이 발생해 `train.py` 파일의 20L 에 `num_workers` 파라미터를 추가해 데이터를 한번에 전달 하여 gpu 성능을 최대한 활용할수 있게하였습니다.
기존 코드는 데이터 전달량이 많지 않아 병목현상이 발생, cuda 프로세서를 사용하지 않아 cpu 사용량이 증가하여 학습 시간에 좋지 못한 영향을 미친것으로 확인, 이를 해결하였습니다. 파라미터 인자는 컴퓨터 사양에 따라 가변적으로 이용할 수 있습니다